### PR TITLE
Modified the function.name matching regex.

### DIFF
--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -366,7 +366,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?&lt;=[\s|\(])[a-zA-Z0-9_-]+(\()</string>
+			<string>(?&lt;=[\s|\(])(?!url|format|attr)[a-zA-Z0-9_-][\w-]*(?=\()</string>
 			<key>name</key>
 			<string>support.function.name.sass</string>
 		</dict>


### PR DESCRIPTION
Original function.name regex included the following parenthesis in the match, which I found a little distracting. I also made it omit some standard CSS syntax.
