### PR TITLE
Improving code folding for SCSS syntax in Textmate

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -7,9 +7,9 @@
 		<string>scss</string>
 	</array>
 	<key>foldingStartMarker</key>
-	<string>/\*|^#|^\*|^\b|^\.</string>
+	<string>/\*\*(?!\*)|\{\s*($|/\*(?!.*?\*/.*\S))|\/\*\s*@group\s*.*\s*\*\/</string>
 	<key>foldingStopMarker</key>
-	<string>\*/|^\s*$</string>
+	<string>(?<!\*)\*\*/|^\s*\}|\/*\s*@end\s*\*\/</string>
 	<key>name</key>
 	<string>SCSS</string>
 	<key>patterns</key>


### PR DESCRIPTION
This patch borrows the code folding markers from the CSS bundle.
