### PR TITLE
Vmax units added

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -638,7 +638,7 @@
 		<key>unit</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=[\d]|})(ch|cm|deg|dpcm|dpi|dppx|em|ex|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmin|vw|%)</string>
+			<string>(?&lt;=[\d]|})(ch|cm|deg|dpcm|dpi|dppx|em|ex|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmax|vmin|vw|%)</string>
 			<key>name</key>
 			<string>keyword.other.unit.css.sass</string>
 		</dict>

--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -689,7 +689,7 @@
 		<key>unit</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=[\d]|})(ch|cm|deg|dpcm|dpi|dppx|em|ex|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmin|vw|%)</string>
+			<string>(?&lt;=[\d]|})(ch|cm|deg|dpcm|dpi|dppx|em|ex|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmax|vmin|vw|%)</string>
 			<key>name</key>
 			<string>keyword.other.unit.css.sass</string>
 		</dict>


### PR DESCRIPTION
The only missing unit from [CSS 3 Values and Units](http://www.w3.org/TR/css3-values/#viewport-relative-lengths).
