### PR TITLE
Support highlighting of css.sass and css.scss filetypes

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -4,6 +4,7 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
+		<string>css.scss</string>
 		<string>scss</string>
 	</array>
 	<key>foldingStartMarker</key>

--- a/Syntaxes/Sass.tmLanguage
+++ b/Syntaxes/Sass.tmLanguage
@@ -4,6 +4,7 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
+		<string>css.sass</string>
 		<string>sass</string>
 	</array>
 	<key>foldingStartMarker</key>


### PR DESCRIPTION
This adds highlighting for `css.sass` and `css.scss` file endings used by Ruby on Rails: http://guides.rubyonrails.org/asset_pipeline.html

I tried searching but did not manage find any discussion about this, so hopefully this won't break anything.
